### PR TITLE
ネストされたkeyを指定することが可能に

### DIFF
--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -2,18 +2,28 @@ package cmd
 
 import "fmt"
 
-func Extract(key string, value string, yamls []map[string]interface{}) [][]byte {
+// Extract keyLists example: [metadata, name]
+func Extract(keyLists []string, value string, yamls []map[string]interface{}) [][]byte {
 	var extracted [][]byte
 	for _, y := range yamls {
-		if y[key] == nil || y[key] != value {
-			continue
+		t := y
+		for i, k := range keyLists {
+			if i < (len(keyLists) - 1) {
+				w := t[k]
+				t = w.(map[string]interface{})
+				continue
+			} else {
+				if t[k] == value {
+					s, err := ParseToString(y)
+					if err != nil {
+						fmt.Errorf("%s", err)
+						return nil
+					}
+					extracted = append(extracted, s)
+					break
+				}
+			}
 		}
-		s, err := ParseToString(y)
-		if err != nil {
-			fmt.Errorf("%s", err)
-			return nil
-		}
-		extracted = append(extracted, s)
 	}
 	return extracted
 }

--- a/cmd/input.go
+++ b/cmd/input.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"io"
 	"os"
+	"strings"
 )
 
 func Pipe() ([]byte, error) {
@@ -15,9 +16,10 @@ func Pipe() ([]byte, error) {
 	return b, nil
 }
 
-func Flag() (*string, *string) {
+func Flag() ([]string, *string) {
 	k := flag.String("k", "", "key")
 	v := flag.String("v", "", "value")
 	flag.Parse()
-	return k, v
+	kl := strings.Split(*k, ".")
+	return kl, v
 }

--- a/main.go
+++ b/main.go
@@ -32,8 +32,8 @@ func main() {
 		err.Error()
 	}
 
-	k, v := cmd.Flag()
-	extractedYaml := cmd.Extract(*k, *v, cmd.ParseToYaml(r))
+	kl, v := cmd.Flag()
+	extractedYaml := cmd.Extract(kl, *v, cmd.ParseToYaml(r))
 
 	for _, y := range extractedYaml {
 		fmt.Println("---")


### PR DESCRIPTION
以下のような指定が可能になる。
key名にドットが含まれるのはまだ無理(例: `nginx.ingress.kubernetes.io/rewrite-target:`)
```
$ cat multiple_documents.yaml | emkr -k metadata.labels.app -v hoge

>  ---
   apiVersion: apps/v1
   kind: Deployment
   metadata:
     name: hoge-deployment
     labels:
       app: hoge
   spec:
     replicas: 3
     selector:
       matchLabels:
         app: hoge
     template:
       metadata:
         labels:
           app: hoge
       spec:
         containers:
         - name: apps
           image: hogeapp:1.0
```
